### PR TITLE
Fix for "artisan config:cache"

### DIFF
--- a/src/Drivers/GoogleTranslator.php
+++ b/src/Drivers/GoogleTranslator.php
@@ -11,7 +11,11 @@ class GoogleTranslator implements TranslatorInterface
 
     public function __construct()
     {
-        $this->client = new TranslateClient();
+        $keyFilePath = config('translatable.keyFilePath');
+
+        $config = $keyFilePath ? compact('keyFilePath') : [];
+
+        $this->client = new TranslateClient($config);
     }
 
     public function detectLanguage($text)


### PR DESCRIPTION
.env variables after config:cache are no longer available. Google will fail to find the correct path to the key file as `getenv()` will return `false`. This change manually adds the keyFilePath for Google's TranslateClient (only if this value exists).